### PR TITLE
Turn fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.14)
 
-project(ale VERSION 0.1.6
+project(ale VERSION 0.1.7
             DESCRIPTION "The Arcade Learning Environment (ALE) - a platform for AI research."
             HOMEPAGE_URL "http://www.arcadelearningenvironment.org"
             LANGUAGES CXX)

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -275,7 +275,9 @@ void ALEInterface::setFloat(const std::string& key, const float value) {
 }
 
 // Resets the game, but not the full system.
-void ALEInterface::reset_game() { environment->reset(); }
+void ALEInterface::reset_game() {
+  environment->reset();
+}
 
 // Indicates if the game has ended.
 bool ALEInterface::game_over() const { return environment->isTerminal(); }

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -595,6 +595,7 @@ void Settings::setDefaultSettings() {
     boolSettings.insert(pair<string, bool>("color_averaging", false));
     boolSettings.insert(pair<string, bool>("send_rgb", false));
     intSettings.insert(pair<string, int>("frame_skip", 1));
+    intSettings.insert(pair<string, int>("stall_penalty_limit", -1));
     floatSettings.insert(pair<string, float>("repeat_action_probability", 0.25));
     stringSettings.insert(pair<string, string>("rom_file", ""));
 

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -595,7 +595,7 @@ void Settings::setDefaultSettings() {
     boolSettings.insert(pair<string, bool>("color_averaging", false));
     boolSettings.insert(pair<string, bool>("send_rgb", false));
     intSettings.insert(pair<string, int>("frame_skip", 1));
-    intSettings.insert(pair<string, int>("stall_penalty_limit", -1));
+    intSettings.insert(pair<string, int>("stall_time", -1));
     floatSettings.insert(pair<string, float>("repeat_action_probability", 0.25));
     stringSettings.insert(pair<string, string>("rom_file", ""));
 

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -595,7 +595,7 @@ void Settings::setDefaultSettings() {
     boolSettings.insert(pair<string, bool>("color_averaging", false));
     boolSettings.insert(pair<string, bool>("send_rgb", false));
     intSettings.insert(pair<string, int>("frame_skip", 1));
-    intSettings.insert(pair<string, int>("stall_time", -1));
+    intSettings.insert(pair<string, int>("max_turn_time", -1));
     floatSettings.insert(pair<string, float>("repeat_action_probability", 0.25));
     stringSettings.insert(pair<string, string>("rom_file", ""));
 

--- a/src/games/RomSettings.cpp
+++ b/src/games/RomSettings.cpp
@@ -71,8 +71,8 @@ DifficultyVect RomSettings::getAvailableDifficulties() {
   return DifficultyVect(1, 0);
 }
 
-bool RomSettings::isModeSupported(game_mode_t m) {
-  auto modes = getAvailableModes();
+bool RomSettings::isModeSupported(game_mode_t m, int players) {
+  auto modes = (players == 1) ? getAvailableModes() : ((players == 2) ? get2PlayerModes() : get4PlayerModes()) ;
   return std::find(modes.begin(), modes.end(), m) != modes.end();
 }
 #define xstr(a) str(a)

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -138,7 +138,7 @@ class RomSettings {
   //multiplayer methods
  protected:
   // Helper function that checks if our settings support this given mode.
-  bool isModeSupported(game_mode_t m);
+  bool isModeSupported(game_mode_t m, int players=1);
 };
 
 }  // namespace ale

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -56,6 +56,7 @@ void DoubleDunkSettings::step(const System& system) {
         m_reward_p1 = -1;
         m_reward_p2 = 0;
       }
+      no_choice_counter = 0;
     }
   }
 }

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -29,8 +29,7 @@ void DoubleDunkSettings::step(const System& system) {
   int my_score = getDecimalScore(0xF6, &system);
   int oppt_score = getDecimalScore(0xF7, &system);
   int score = my_score - oppt_score;
-  m_reward_p1 = score - m_score;
-  m_reward_p2 = -m_reward_p1;
+  m_reward = score - m_score;
   m_score = score;
 
   // update terminal status
@@ -45,16 +44,16 @@ void DoubleDunkSettings::step(const System& system) {
     no_choice_counter++;
     if(stall_time > 0 && no_choice_counter > stall_time){
       if(choice_value == 0){
-        m_reward_p1 = -1;
-        m_reward_p2 = -1;
+        //neither player made a selection
+        m_reward = 0;
       }
       else if(choice_value&0x40){
-        m_reward_p1 = 0;
-        m_reward_p2 = -1;
+        //player 1 made a selection, player 2 did not
+        m_reward = 1;
       }
       else if(choice_value&0x80){
-        m_reward_p1 = -1;
-        m_reward_p2 = 0;
+        //player 2 made a selection, player 2 did not
+        m_reward = -1;
       }
       no_choice_counter = 0;
     }
@@ -65,8 +64,8 @@ void DoubleDunkSettings::step(const System& system) {
 bool DoubleDunkSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DoubleDunkSettings::getReward() const { return m_reward_p1; }
-reward_t DoubleDunkSettings::getRewardP2() const { return m_reward_p2; }
+reward_t DoubleDunkSettings::getReward() const { return m_reward; }
+reward_t DoubleDunkSettings::getRewardP2() const { return -m_reward; }
 
 /* is an action part of the minimal set? */
 bool DoubleDunkSettings::isMinimal(const Action& a) const {
@@ -97,8 +96,7 @@ bool DoubleDunkSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void DoubleDunkSettings::reset() {
-  m_reward_p1 = 0;
-  m_reward_p2 = 0;
+  m_reward = 0;
   m_score = 0;
   no_choice_counter = 0;
   m_terminal = false;
@@ -106,8 +104,7 @@ void DoubleDunkSettings::reset() {
 
 /* saves the state of the rom settings */
 void DoubleDunkSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward_p1);
-  ser.putInt(m_reward_p2);
+  ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putInt(stall_time);
   ser.putInt(no_choice_counter);
@@ -116,8 +113,7 @@ void DoubleDunkSettings::saveState(Serializer& ser) {
 
 // loads the state of the rom settings
 void DoubleDunkSettings::loadState(Deserializer& ser) {
-  m_reward_p1 = ser.getInt();
-  m_reward_p2 = ser.getInt();
+  m_reward = ser.getInt();
   m_score = ser.getInt();
   stall_time = ser.getInt();
   no_choice_counter = ser.getInt();

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -43,7 +43,7 @@ void DoubleDunkSettings::step(const System& system) {
       no_choice_counter = 0;
     }
     no_choice_counter++;
-    if(stall_penalty_limit > 0 && no_choice_counter > stall_penalty_limit){
+    if(stall_time > 0 && no_choice_counter > stall_time){
       if(choice_value == 0){
         m_reward_p1 = -1;
         m_reward_p2 = -1;
@@ -109,7 +109,7 @@ void DoubleDunkSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward_p1);
   ser.putInt(m_reward_p2);
   ser.putInt(m_score);
-  ser.putInt(stall_penalty_limit);
+  ser.putInt(stall_time);
   ser.putInt(no_choice_counter);
   ser.putBool(m_terminal);
 }
@@ -119,7 +119,7 @@ void DoubleDunkSettings::loadState(Deserializer& ser) {
   m_reward_p1 = ser.getInt();
   m_reward_p2 = ser.getInt();
   m_score = ser.getInt();
-  stall_penalty_limit = ser.getInt();
+  stall_time = ser.getInt();
   no_choice_counter = ser.getInt();
   m_terminal = ser.getBool();
 }
@@ -241,10 +241,10 @@ void DoubleDunkSettings::setMode(
 
 void DoubleDunkSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_penalty_limit = settings.getInt("stall_penalty_limit");
-  if(stall_penalty_limit == default_setting){
+  stall_time = settings.getInt("stall_time");
+  if(stall_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*2;
-    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+    stall_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -56,7 +56,6 @@ void DoubleDunkSettings::step(const System& system) {
         m_reward_p1 = -1;
         m_reward_p2 = 0;
       }
-      m_terminal = true;
     }
   }
 }

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -29,7 +29,8 @@ void DoubleDunkSettings::step(const System& system) {
   int my_score = getDecimalScore(0xF6, &system);
   int oppt_score = getDecimalScore(0xF7, &system);
   int score = my_score - oppt_score;
-  m_reward = score - m_score;
+  m_reward_p1 = score - m_score;
+  m_reward_p2 = -m_reward_p1;
   m_score = score;
 
   // update terminal status
@@ -44,16 +45,16 @@ void DoubleDunkSettings::step(const System& system) {
     no_choice_counter++;
     if(max_turn_time > 0 && no_choice_counter > max_turn_time){
       if(choice_value == 0){
-        //neither player made a selection
-        m_reward = 0;
+        m_reward_p1 = -1;
+        m_reward_p2 = -1;
       }
       else if(choice_value&0x40){
-        //player 1 made a selection, player 2 did not
-        m_reward = 1;
+        m_reward_p1 = 0;
+        m_reward_p2 = -1;
       }
       else if(choice_value&0x80){
-        //player 2 made a selection, player 2 did not
-        m_reward = -1;
+        m_reward_p1 = -1;
+        m_reward_p2 = 0;
       }
       no_choice_counter = 0;
     }
@@ -64,8 +65,8 @@ void DoubleDunkSettings::step(const System& system) {
 bool DoubleDunkSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DoubleDunkSettings::getReward() const { return m_reward; }
-reward_t DoubleDunkSettings::getRewardP2() const { return -m_reward; }
+reward_t DoubleDunkSettings::getReward() const { return m_reward_p1; }
+reward_t DoubleDunkSettings::getRewardP2() const { return m_reward_p2; }
 
 /* is an action part of the minimal set? */
 bool DoubleDunkSettings::isMinimal(const Action& a) const {
@@ -96,7 +97,8 @@ bool DoubleDunkSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void DoubleDunkSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
   m_score = 0;
   no_choice_counter = 0;
   m_terminal = false;
@@ -104,7 +106,8 @@ void DoubleDunkSettings::reset() {
 
 /* saves the state of the rom settings */
 void DoubleDunkSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
   ser.putInt(m_score);
   ser.putInt(max_turn_time);
   ser.putInt(no_choice_counter);
@@ -113,7 +116,8 @@ void DoubleDunkSettings::saveState(Serializer& ser) {
 
 // loads the state of the rom settings
 void DoubleDunkSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
   m_score = ser.getInt();
   max_turn_time = ser.getInt();
   no_choice_counter = ser.getInt();

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -29,20 +29,44 @@ void DoubleDunkSettings::step(const System& system) {
   int my_score = getDecimalScore(0xF6, &system);
   int oppt_score = getDecimalScore(0xF7, &system);
   int score = my_score - oppt_score;
-  m_reward = score - m_score;
+  m_reward_p1 = score - m_score;
+  m_reward_p2 = -m_reward_p1;
   m_score = score;
 
   // update terminal status
   int some_value = readRam(&system, 0xFE);
   m_terminal = (my_score >= 24 || oppt_score >= 24) && some_value == 0xE7;
+
+  if(is_two_player){
+    int choice_value = readRam(&system, 0x89);
+    if (!(choice_value == 0 || choice_value&0x80 || choice_value&0x40)){
+      no_choice_counter = 0;
+    }
+    no_choice_counter++;
+    if(stall_penalty_limit > 0 && no_choice_counter > stall_penalty_limit){
+      if(choice_value == 0){
+        m_reward_p1 = -1;
+        m_reward_p2 = -1;
+      }
+      else if(choice_value&0x40){
+        m_reward_p1 = 0;
+        m_reward_p2 = -1;
+      }
+      else if(choice_value&0x80){
+        m_reward_p1 = -1;
+        m_reward_p2 = 0;
+      }
+      m_terminal = true;
+    }
+  }
 }
 
 /* is end of game */
 bool DoubleDunkSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DoubleDunkSettings::getReward() const { return m_reward; }
-reward_t DoubleDunkSettings::getRewardP2() const { return -m_reward; }
+reward_t DoubleDunkSettings::getReward() const { return m_reward_p1; }
+reward_t DoubleDunkSettings::getRewardP2() const { return m_reward_p2; }
 
 /* is an action part of the minimal set? */
 bool DoubleDunkSettings::isMinimal(const Action& a) const {
@@ -73,22 +97,30 @@ bool DoubleDunkSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void DoubleDunkSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
   m_score = 0;
+  no_choice_counter = 0;
   m_terminal = false;
 }
 
 /* saves the state of the rom settings */
 void DoubleDunkSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
   ser.putInt(m_score);
+  ser.putInt(stall_penalty_limit);
+  ser.putInt(no_choice_counter);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
 void DoubleDunkSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
   m_score = ser.getInt();
+  stall_penalty_limit = ser.getInt();
+  no_choice_counter = ser.getInt();
   m_terminal = ser.getBool();
 }
 
@@ -159,8 +191,10 @@ void DoubleDunkSettings::setMode(
     environment->pressSelect();
 
     if(m & 16){
+      is_two_player = true;
       activateOption(system, 0x40, environment);
     } else {
+      is_two_player = false;
       deactivateOption(system, 0x40, environment);
     }
     goDown(system, environment);
@@ -202,6 +236,16 @@ void DoubleDunkSettings::setMode(
     environment->softReset();
     //apply starting action
 
+}
+
+
+void DoubleDunkSettings::modifyEnvironmentSettings(Settings& settings) {
+  int default_setting = -1;
+  stall_penalty_limit = settings.getInt("stall_penalty_limit");
+  if(stall_penalty_limit == default_setting){
+    const int DEFAULT_STALL_LIMIT = 60*2;
+    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+  }
 }
 
 }  // namespace ale

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -42,7 +42,7 @@ void DoubleDunkSettings::step(const System& system) {
       no_choice_counter = 0;
     }
     no_choice_counter++;
-    if(stall_time > 0 && no_choice_counter > stall_time){
+    if(max_turn_time > 0 && no_choice_counter > max_turn_time){
       if(choice_value == 0){
         //neither player made a selection
         m_reward = 0;
@@ -106,7 +106,7 @@ void DoubleDunkSettings::reset() {
 void DoubleDunkSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
-  ser.putInt(stall_time);
+  ser.putInt(max_turn_time);
   ser.putInt(no_choice_counter);
   ser.putBool(m_terminal);
 }
@@ -115,7 +115,7 @@ void DoubleDunkSettings::saveState(Serializer& ser) {
 void DoubleDunkSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
-  stall_time = ser.getInt();
+  max_turn_time = ser.getInt();
   no_choice_counter = ser.getInt();
   m_terminal = ser.getBool();
 }
@@ -237,10 +237,10 @@ void DoubleDunkSettings::setMode(
 
 void DoubleDunkSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_time = settings.getInt("stall_time");
-  if(stall_time == default_setting){
+  max_turn_time = settings.getInt("max_turn_time");
+  if(max_turn_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*2;
-    stall_time = DEFAULT_STALL_LIMIT;
+    max_turn_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -90,7 +90,8 @@ class DoubleDunkSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   reward_t m_score;
   int max_turn_time;
   int no_choice_counter;

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -54,6 +54,8 @@ class DoubleDunkSettings : public RomSettings2P {
   // The md5 checksum of the ROM that this game supports
   const char* md5() const override { return "368d88a6c071caba60b4f778615aae94"; }
 
+  virtual void modifyEnvironmentSettings(Settings& settings);
+
   // get the available number of modes
   unsigned int getNumModes() const { return 16; }
 
@@ -88,8 +90,12 @@ class DoubleDunkSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   reward_t m_score;
+  int stall_penalty_limit;
+  int no_choice_counter;
+  bool is_two_player;
 
   // this game has a menu that allows to define various yes/no options
   // this function goes to the next option in the menu

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -92,7 +92,7 @@ class DoubleDunkSettings : public RomSettings2P {
   bool m_terminal;
   reward_t m_reward;
   reward_t m_score;
-  int stall_time;
+  int max_turn_time;
   int no_choice_counter;
   bool is_two_player;
 

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -90,8 +90,7 @@ class DoubleDunkSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward_p1;
-  reward_t m_reward_p2;
+  reward_t m_reward;
   reward_t m_score;
   int stall_time;
   int no_choice_counter;

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -93,7 +93,7 @@ class DoubleDunkSettings : public RomSettings2P {
   reward_t m_reward_p1;
   reward_t m_reward_p2;
   reward_t m_score;
-  int stall_penalty_limit;
+  int stall_time;
   int no_choice_counter;
   bool is_two_player;
 

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -62,7 +62,7 @@ void OthelloSettings::step(const System& system) {
   }
   turn_same_count += 1;
   // 15 second timer to move
-  if (stall_time > 0 && turn_same_count >= stall_time){
+  if (max_turn_time > 0 && turn_same_count >= max_turn_time){
     unsigned char active_player = readRam(&system, 0xc0);
     // not moving is made to be the worst possible action, receiving total of 0 score.
     if (active_player == 0xff){
@@ -116,7 +116,7 @@ void OthelloSettings::saveState(Serializer& ser) {
   ser.putBool(m_terminal);
   ser.putBool(two_player_mode);
   ser.putInt(m_cursor_inactive);
-  ser.putInt(stall_time);
+  ser.putInt(max_turn_time);
 }
 
 void OthelloSettings::loadState(Deserializer& ser) {
@@ -126,7 +126,7 @@ void OthelloSettings::loadState(Deserializer& ser) {
   m_terminal = ser.getBool();
   two_player_mode = ser.getBool();
   m_cursor_inactive = ser.getInt();
-  stall_time = ser.getInt();
+  max_turn_time = ser.getInt();
 }
 
 // According to https://atariage.com/manual_html_page.php?SoftwareLabelID=931
@@ -172,10 +172,10 @@ void OthelloSettings::setMode(
 
 void OthelloSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_time = settings.getInt("stall_time");
-  if(stall_time == default_setting){
+  max_turn_time = settings.getInt("max_turn_time");
+  if(max_turn_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*10;
-    stall_time = DEFAULT_STALL_LIMIT;
+    max_turn_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -63,7 +63,7 @@ void OthelloSettings::step(const System& system) {
   }
   turn_same_count += 1;
   // 15 second timer to move
-  if (stall_penalty_limit > 0 && turn_same_count >= stall_penalty_limit){
+  if (stall_time > 0 && turn_same_count >= stall_time){
     unsigned char active_player = readRam(&system, 0xc0);
     // not moving is made to be the worst possible action, receiving total of 0 score.
     if (active_player == 0xff){
@@ -119,7 +119,7 @@ void OthelloSettings::saveState(Serializer& ser) {
   ser.putBool(m_terminal);
   ser.putBool(two_player_mode);
   ser.putInt(m_cursor_inactive);
-  ser.putInt(stall_penalty_limit);
+  ser.putInt(stall_time);
 }
 
 void OthelloSettings::loadState(Deserializer& ser) {
@@ -130,7 +130,7 @@ void OthelloSettings::loadState(Deserializer& ser) {
   m_terminal = ser.getBool();
   two_player_mode = ser.getBool();
   m_cursor_inactive = ser.getInt();
-  stall_penalty_limit = ser.getInt();
+  stall_time = ser.getInt();
 }
 
 // According to https://atariage.com/manual_html_page.php?SoftwareLabelID=931
@@ -176,10 +176,10 @@ void OthelloSettings::setMode(
 
 void OthelloSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_penalty_limit = settings.getInt("stall_penalty_limit");
-  if(stall_penalty_limit == default_setting){
+  stall_time = settings.getInt("stall_time");
+  if(stall_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*10;
-    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+    stall_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -65,7 +65,6 @@ void OthelloSettings::step(const System& system) {
     // 15 second timer to move
     if (max_turn_time > 0 && turn_same_count >= max_turn_time){
       unsigned char active_player = readRam(&system, 0xc0);
-      // not moving is made to be the worst possible action, receiving total of 0 score.
       if (active_player == 0xff){
         m_reward_m1 = -1;
       }

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -42,8 +42,8 @@ void OthelloSettings::step(const System& system) {
   m_reward = score - m_score;
   m_score = score;
 
-  // On screen cursor flashes every 4 frames when player input is accepted.
-  if (readRam(&system, 0xe8) == 0) {
+  // Player indicator is zero if game is over
+  if (readRam(&system, 0xc0) == 0) {
     ++m_cursor_inactive;
   } else {
     m_cursor_inactive = 0;
@@ -55,23 +55,24 @@ void OthelloSettings::step(const System& system) {
   // flashing for at least one second, signalling no more player input.
   m_terminal = m_cursor_inactive > 75;
 
-
-  if (m_reward != 0){
-    // reward is non-zero every time there is a turn change
-    turn_same_count = 0;
-  }
-  turn_same_count += 1;
-  // 15 second timer to move
-  if (max_turn_time > 0 && turn_same_count >= max_turn_time){
-    unsigned char active_player = readRam(&system, 0xc0);
-    // not moving is made to be the worst possible action, receiving total of 0 score.
-    if (active_player == 0xff){
-      m_reward = -white_score;
+  if(two_player_mode){
+    if (m_reward != 0){
+      // reward is non-zero every time there is a turn change
+      turn_same_count = 0;
     }
-    else{
-      m_reward = black_score;
+    turn_same_count += 1;
+    // 15 second timer to move
+    if (max_turn_time > 0 && turn_same_count >= max_turn_time){
+      unsigned char active_player = readRam(&system, 0xc0);
+      // not moving is made to be the worst possible action, receiving total of 0 score.
+      if (active_player == 0xff){
+        m_reward = -white_score;
+      }
+      else{
+        m_reward = black_score;
+      }
+      turn_same_count = 0;
     }
-    turn_same_count = 0;
   }
 }
 

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -72,6 +72,7 @@ void OthelloSettings::step(const System& system) {
     else{
       m_reward_m2 = -black_score;
     }
+    turn_same_count = 0;
   }
 }
 

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -39,8 +39,7 @@ void OthelloSettings::step(const System& system) {
   int white_score = getDecimalScore(0xce, &system);
   int black_score = getDecimalScore(0xd0, &system);
   int score = white_score - black_score;
-  m_reward_m1 = score - m_score;
-  m_reward_m2 = -m_reward_m1;
+  m_reward = score - m_score;
   m_score = score;
 
   // On screen cursor flashes every 4 frames when player input is accepted.
@@ -57,7 +56,7 @@ void OthelloSettings::step(const System& system) {
   m_terminal = m_cursor_inactive > 75;
 
 
-  if (m_reward_m1 != 0){
+  if (m_reward != 0){
     // reward is non-zero every time there is a turn change
     turn_same_count = 0;
   }
@@ -67,10 +66,10 @@ void OthelloSettings::step(const System& system) {
     unsigned char active_player = readRam(&system, 0xc0);
     // not moving is made to be the worst possible action, receiving total of 0 score.
     if (active_player == 0xff){
-      m_reward_m1 = -white_score;
+      m_reward = -white_score;
     }
     else{
-      m_reward_m2 = -black_score;
+      m_reward = black_score;
     }
     turn_same_count = 0;
   }
@@ -78,8 +77,8 @@ void OthelloSettings::step(const System& system) {
 
 bool OthelloSettings::isTerminal() const { return m_terminal; }
 
-reward_t OthelloSettings::getReward() const { return m_reward_m1; }
-reward_t OthelloSettings::getRewardP2() const { return m_reward_m2; }
+reward_t OthelloSettings::getReward() const { return m_reward; }
+reward_t OthelloSettings::getRewardP2() const { return -m_reward; }
 
 bool OthelloSettings::isMinimal(const Action& a) const {
   switch (a) {
@@ -103,8 +102,7 @@ bool OthelloSettings::isMinimal(const Action& a) const {
 }
 
 void OthelloSettings::reset() {
-  m_reward_m1 = 0;
-  m_reward_m2 = 0;
+  m_reward = 0;
   m_score = 0;
   turn_same_count = 0;
   m_terminal = false;
@@ -112,8 +110,7 @@ void OthelloSettings::reset() {
 }
 
 void OthelloSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward_m1);
-  ser.putInt(m_reward_m2);
+  ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putInt(turn_same_count);
   ser.putBool(m_terminal);
@@ -123,8 +120,7 @@ void OthelloSettings::saveState(Serializer& ser) {
 }
 
 void OthelloSettings::loadState(Deserializer& ser) {
-  m_reward_m1 = ser.getInt();
-  m_reward_m2 = ser.getInt();
+  m_reward = ser.getInt();
   m_score = ser.getInt();
   turn_same_count = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -67,10 +67,10 @@ void OthelloSettings::step(const System& system) {
       unsigned char active_player = readRam(&system, 0xc0);
       // not moving is made to be the worst possible action, receiving total of 0 score.
       if (active_player == 0xff){
-        m_reward_m1 = -white_score;
+        m_reward_m1 = -1;
       }
       else{
-        m_reward_m2 = -black_score;
+        m_reward_m2 = -1;
       }
       turn_same_count = 0;
     }

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -72,7 +72,6 @@ void OthelloSettings::step(const System& system) {
     else{
       m_reward_m2 = -black_score;
     }
-    m_terminal = true;
   }
 }
 

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -71,7 +71,7 @@ class OthelloSettings : public RomSettings2P {
   bool m_terminal;
   int turn_same_count;
   bool two_player_mode;
-  int stall_penalty_limit;
+  int stall_time;
   reward_t m_reward_m1;
   reward_t m_reward_m2;
   int m_score;

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -72,7 +72,8 @@ class OthelloSettings : public RomSettings2P {
   int turn_same_count;
   bool two_player_mode;
   int max_turn_time;
-  reward_t m_reward;
+  reward_t m_reward_m1;
+  reward_t m_reward_m2;
   int m_score;
   int m_cursor_inactive;
 };

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -72,8 +72,7 @@ class OthelloSettings : public RomSettings2P {
   int turn_same_count;
   bool two_player_mode;
   int stall_time;
-  reward_t m_reward_m1;
-  reward_t m_reward_m2;
+  reward_t m_reward;
   int m_score;
   int m_cursor_inactive;
 };

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -71,7 +71,7 @@ class OthelloSettings : public RomSettings2P {
   bool m_terminal;
   int turn_same_count;
   bool two_player_mode;
-  int stall_time;
+  int max_turn_time;
   reward_t m_reward;
   int m_score;
   int m_cursor_inactive;

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -44,6 +44,8 @@ class OthelloSettings : public RomSettings2P {
 
   virtual const char* rom() const { return "othello"; }
 
+  virtual void modifyEnvironmentSettings(Settings& settings);
+
   // The md5 checksum of the ROM that this game supports
   const char* md5() const override { return "113cd09c9771ac278544b7e90efe7df2"; }
 
@@ -67,7 +69,11 @@ class OthelloSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward;
+  int turn_same_count;
+  bool two_player_mode;
+  int stall_penalty_limit;
+  reward_t m_reward_m1;
+  reward_t m_reward_m2;
   int m_score;
   int m_cursor_inactive;
 };

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -34,13 +34,18 @@ void TennisSettings::step(const System& system) {
   int delta_points = my_points - oppt_points;
 
   // a reward for the game
-  if (m_prev_delta_points != delta_points)
-    m_reward = delta_points - m_prev_delta_points;
+  if (m_prev_delta_points != delta_points){
+    m_reward_p1 = delta_points - m_prev_delta_points;
+    turn_counter += 1;
+  }
   // a reward for each point
-  else if (m_prev_delta_score != delta_score)
-    m_reward = delta_score - m_prev_delta_score;
-  else
-    m_reward = 0;
+  else if (m_prev_delta_score != delta_score){
+    m_reward_p1 = delta_score - m_prev_delta_score;
+  }
+  else{
+    m_reward_p1 = 0;
+  }
+  m_reward_p2 = -m_reward_p1;
 
   m_prev_delta_points = delta_points;
   m_prev_delta_score = delta_score;
@@ -49,14 +54,34 @@ void TennisSettings::step(const System& system) {
   m_terminal = (my_points >= 6 && delta_points >= 2) ||
                (oppt_points >= 6 && -delta_points >= 2) ||
                (my_points == 7 || oppt_points == 7);
+
+  if (two_player_mode){
+    // serve stalling is not possible to happen alongside scoring, so this will
+    //not overwrite previously calculated scored/terminal above
+    int serve_stall_counter = readRam(&system, 0xcc);
+    // times out serve after 3 seconds in two player mode
+    // to disallow stalling
+    if (serve_stall_counter >= 3){
+       // timed out serve on agent:
+       if(turn_counter % 2 == 0){
+         m_reward_p1 = -1;
+         m_reward_p2 = 0;
+       }
+       else{
+         m_reward_p1 = 0;
+         m_reward_p2 = -1;
+       }
+       m_terminal = true;
+     }
+  }
 }
 
 /* is end of game */
 bool TennisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TennisSettings::getReward() const { return m_reward; }
-reward_t TennisSettings::getRewardP2() const { return -m_reward; }
+reward_t TennisSettings::getReward() const { return m_reward_p1; }
+reward_t TennisSettings::getRewardP2() const { return m_reward_p2; }
 
 /* is an action part of the minimal set? */
 bool TennisSettings::isMinimal(const Action& a) const {
@@ -87,16 +112,21 @@ bool TennisSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void TennisSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
   m_prev_delta_points = 0;
+  turn_counter = 0;
   m_prev_delta_score = 0;
   m_terminal = false;
 }
 
 /* saves the state of the rom settings */
 void TennisSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
+  ser.putInt(turn_counter);
   ser.putBool(m_terminal);
+  ser.putBool(two_player_mode);
 
   ser.putInt(m_prev_delta_points);
   ser.putInt(m_prev_delta_score);
@@ -104,8 +134,11 @@ void TennisSettings::saveState(Serializer& ser) {
 
 // loads the state of the rom settings
 void TennisSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
+  turn_counter = ser.getInt();
   m_terminal = ser.getBool();
+  two_player_mode = ser.getBool();
 
   m_prev_delta_points = ser.getInt();
   m_prev_delta_score = ser.getInt();
@@ -127,6 +160,7 @@ void TennisSettings::setMode(
 
     game_mode_t target_m = m - 1;
 
+    two_player_mode = isModeSupported(m, 2);
     // read the mode we are currently in
     unsigned char mode = readRam(&system, 0x80);
     // press select until the correct mode is reached

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -35,16 +35,17 @@ void TennisSettings::step(const System& system) {
 
   // a reward for the game
   if (m_prev_delta_points != delta_points){
-    m_reward = delta_points - m_prev_delta_points;
+    m_reward_p1 = delta_points - m_prev_delta_points;
     turn_counter += 1;
   }
   // a reward for each point
   else if (m_prev_delta_score != delta_score){
-    m_reward = delta_score - m_prev_delta_score;
+    m_reward_p1 = delta_score - m_prev_delta_score;
   }
   else{
-    m_reward = 0;
+    m_reward_p1 = 0;
   }
+  m_reward_p2 = -m_reward_p1;
 
   m_prev_delta_points = delta_points;
   m_prev_delta_score = delta_score;
@@ -67,10 +68,12 @@ void TennisSettings::step(const System& system) {
     if (max_turn_time > 0 && no_serve_counter >= max_turn_time){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
-         m_reward = -1;
+         m_reward_p1 = -1;
+         m_reward_p2 = 0;
        }
        else{
-         m_reward = 1;
+         m_reward_p1 = 0;
+         m_reward_p2 = -1;
        }
        no_serve_counter = 0;
      }
@@ -81,8 +84,8 @@ void TennisSettings::step(const System& system) {
 bool TennisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TennisSettings::getReward() const { return m_reward; }
-reward_t TennisSettings::getRewardP2() const { return -m_reward; }
+reward_t TennisSettings::getReward() const { return m_reward_p1; }
+reward_t TennisSettings::getRewardP2() const { return m_reward_p2; }
 
 /* is an action part of the minimal set? */
 bool TennisSettings::isMinimal(const Action& a) const {
@@ -113,7 +116,8 @@ bool TennisSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void TennisSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
   m_prev_delta_points = 0;
   turn_counter = 0;
   no_serve_counter = 0;
@@ -123,7 +127,8 @@ void TennisSettings::reset() {
 
 /* saves the state of the rom settings */
 void TennisSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
   ser.putInt(turn_counter);
   ser.putInt(no_serve_counter);
   ser.putBool(m_terminal);
@@ -136,7 +141,8 @@ void TennisSettings::saveState(Serializer& ser) {
 
 // loads the state of the rom settings
 void TennisSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
   turn_counter = ser.getInt();
   no_serve_counter = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -35,17 +35,16 @@ void TennisSettings::step(const System& system) {
 
   // a reward for the game
   if (m_prev_delta_points != delta_points){
-    m_reward_p1 = delta_points - m_prev_delta_points;
+    m_reward = delta_points - m_prev_delta_points;
     turn_counter += 1;
   }
   // a reward for each point
   else if (m_prev_delta_score != delta_score){
-    m_reward_p1 = delta_score - m_prev_delta_score;
+    m_reward = delta_score - m_prev_delta_score;
   }
   else{
-    m_reward_p1 = 0;
+    m_reward = 0;
   }
-  m_reward_p2 = -m_reward_p1;
 
   m_prev_delta_points = delta_points;
   m_prev_delta_score = delta_score;
@@ -68,12 +67,10 @@ void TennisSettings::step(const System& system) {
     if (stall_time > 0 && no_serve_counter >= stall_time){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
-         m_reward_p1 = -1;
-         m_reward_p2 = 0;
+         m_reward = -1;
        }
        else{
-         m_reward_p1 = 0;
-         m_reward_p2 = -1;
+         m_reward = 1;
        }
        no_serve_counter = 0;
      }
@@ -84,8 +81,8 @@ void TennisSettings::step(const System& system) {
 bool TennisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TennisSettings::getReward() const { return m_reward_p1; }
-reward_t TennisSettings::getRewardP2() const { return m_reward_p2; }
+reward_t TennisSettings::getReward() const { return m_reward; }
+reward_t TennisSettings::getRewardP2() const { return -m_reward; }
 
 /* is an action part of the minimal set? */
 bool TennisSettings::isMinimal(const Action& a) const {
@@ -116,8 +113,7 @@ bool TennisSettings::isMinimal(const Action& a) const {
 
 /* reset the state of the game */
 void TennisSettings::reset() {
-  m_reward_p1 = 0;
-  m_reward_p2 = 0;
+  m_reward = 0;
   m_prev_delta_points = 0;
   turn_counter = 0;
   no_serve_counter = 0;
@@ -127,8 +123,7 @@ void TennisSettings::reset() {
 
 /* saves the state of the rom settings */
 void TennisSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward_p1);
-  ser.putInt(m_reward_p2);
+  ser.putInt(m_reward);
   ser.putInt(turn_counter);
   ser.putInt(no_serve_counter);
   ser.putBool(m_terminal);
@@ -141,8 +136,7 @@ void TennisSettings::saveState(Serializer& ser) {
 
 // loads the state of the rom settings
 void TennisSettings::loadState(Deserializer& ser) {
-  m_reward_p1 = ser.getInt();
-  m_reward_p2 = ser.getInt();
+  m_reward = ser.getInt();
   turn_counter = ser.getInt();
   no_serve_counter = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -64,7 +64,7 @@ void TennisSettings::step(const System& system) {
     no_serve_counter += 1;
     // times out serve after 3 seconds in two player mode
     // to disallow stalling
-    if (stall_time > 0 && no_serve_counter >= stall_time){
+    if (max_turn_time > 0 && no_serve_counter >= max_turn_time){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
          m_reward = -1;
@@ -131,7 +131,7 @@ void TennisSettings::saveState(Serializer& ser) {
 
   ser.putInt(m_prev_delta_points);
   ser.putInt(m_prev_delta_score);
-  ser.putInt(stall_time);
+  ser.putInt(max_turn_time);
 }
 
 // loads the state of the rom settings
@@ -144,7 +144,7 @@ void TennisSettings::loadState(Deserializer& ser) {
 
   m_prev_delta_points = ser.getInt();
   m_prev_delta_score = ser.getInt();
-  stall_time = ser.getInt();
+  max_turn_time = ser.getInt();
 }
 
 // returns a list of mode that the game can be played in
@@ -182,10 +182,10 @@ DifficultyVect TennisSettings::getAvailableDifficulties() {
 
 void TennisSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_time = settings.getInt("stall_time");
-  if(stall_time == default_setting){
+  max_turn_time = settings.getInt("max_turn_time");
+  if(max_turn_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*3;
-    stall_time = DEFAULT_STALL_LIMIT;
+    max_turn_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -59,9 +59,13 @@ void TennisSettings::step(const System& system) {
     // serve stalling is not possible to happen alongside scoring, so this will
     //not overwrite previously calculated scored/terminal above
     int serve_stall_counter = readRam(&system, 0xcc);
+    if(serve_stall_counter == 0){
+      no_serve_counter = 0;
+    }
+    no_serve_counter += 1;
     // times out serve after 3 seconds in two player mode
     // to disallow stalling
-    if (stall_penalty_limit > 0 && serve_stall_counter >= (stall_penalty_limit+59)/60){
+    if (stall_penalty_limit > 0 && no_serve_counter >= stall_penalty_limit){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
          m_reward_p1 = -1;
@@ -71,7 +75,6 @@ void TennisSettings::step(const System& system) {
          m_reward_p1 = 0;
          m_reward_p2 = -1;
        }
-       m_terminal = true;
      }
   }
 }
@@ -116,6 +119,7 @@ void TennisSettings::reset() {
   m_reward_p2 = 0;
   m_prev_delta_points = 0;
   turn_counter = 0;
+  no_serve_counter = 0;
   m_prev_delta_score = 0;
   m_terminal = false;
 }
@@ -125,6 +129,7 @@ void TennisSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward_p1);
   ser.putInt(m_reward_p2);
   ser.putInt(turn_counter);
+  ser.putInt(no_serve_counter);
   ser.putBool(m_terminal);
   ser.putBool(two_player_mode);
 
@@ -138,6 +143,7 @@ void TennisSettings::loadState(Deserializer& ser) {
   m_reward_p1 = ser.getInt();
   m_reward_p2 = ser.getInt();
   turn_counter = ser.getInt();
+  no_serve_counter = ser.getInt();
   m_terminal = ser.getBool();
   two_player_mode = ser.getBool();
 

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -75,6 +75,7 @@ void TennisSettings::step(const System& system) {
          m_reward_p1 = 0;
          m_reward_p2 = -1;
        }
+       no_serve_counter = 0;
      }
   }
 }

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -65,7 +65,7 @@ void TennisSettings::step(const System& system) {
     no_serve_counter += 1;
     // times out serve after 3 seconds in two player mode
     // to disallow stalling
-    if (stall_penalty_limit > 0 && no_serve_counter >= stall_penalty_limit){
+    if (stall_time > 0 && no_serve_counter >= stall_time){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
          m_reward_p1 = -1;
@@ -136,7 +136,7 @@ void TennisSettings::saveState(Serializer& ser) {
 
   ser.putInt(m_prev_delta_points);
   ser.putInt(m_prev_delta_score);
-  ser.putInt(stall_penalty_limit);
+  ser.putInt(stall_time);
 }
 
 // loads the state of the rom settings
@@ -150,7 +150,7 @@ void TennisSettings::loadState(Deserializer& ser) {
 
   m_prev_delta_points = ser.getInt();
   m_prev_delta_score = ser.getInt();
-  stall_penalty_limit = ser.getInt();
+  stall_time = ser.getInt();
 }
 
 // returns a list of mode that the game can be played in
@@ -188,10 +188,10 @@ DifficultyVect TennisSettings::getAvailableDifficulties() {
 
 void TennisSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_penalty_limit = settings.getInt("stall_penalty_limit");
-  if(stall_penalty_limit == default_setting){
+  stall_time = settings.getInt("stall_time");
+  if(stall_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*3;
-    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+    stall_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -61,7 +61,7 @@ void TennisSettings::step(const System& system) {
     int serve_stall_counter = readRam(&system, 0xcc);
     // times out serve after 3 seconds in two player mode
     // to disallow stalling
-    if (serve_stall_counter >= 3){
+    if (stall_penalty_limit > 0 && serve_stall_counter >= (stall_penalty_limit+59)/60){
        // timed out serve on agent:
        if(turn_counter % 2 == 0){
          m_reward_p1 = -1;
@@ -130,6 +130,7 @@ void TennisSettings::saveState(Serializer& ser) {
 
   ser.putInt(m_prev_delta_points);
   ser.putInt(m_prev_delta_score);
+  ser.putInt(stall_penalty_limit);
 }
 
 // loads the state of the rom settings
@@ -142,6 +143,7 @@ void TennisSettings::loadState(Deserializer& ser) {
 
   m_prev_delta_points = ser.getInt();
   m_prev_delta_score = ser.getInt();
+  stall_penalty_limit = ser.getInt();
 }
 
 // returns a list of mode that the game can be played in
@@ -174,6 +176,16 @@ void TennisSettings::setMode(
 
 DifficultyVect TennisSettings::getAvailableDifficulties() {
   return {0, 1, 2, 3};
+}
+
+
+void TennisSettings::modifyEnvironmentSettings(Settings& settings) {
+  int default_setting = -1;
+  stall_penalty_limit = settings.getInt("stall_penalty_limit");
+  if(stall_penalty_limit == default_setting){
+    const int DEFAULT_STALL_LIMIT = 60*3;
+    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+  }
 }
 
 }  // namespace ale

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -93,7 +93,7 @@ class TennisSettings : public RomSettings2P {
  private:
   bool m_terminal;
   bool two_player_mode;
-  int stall_penalty_limit;
+  int stall_time;
   int turn_counter;
   int no_serve_counter;
   reward_t m_reward_p1;

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -95,6 +95,7 @@ class TennisSettings : public RomSettings2P {
   bool two_player_mode;
   int stall_penalty_limit;
   int turn_counter;
+  int no_serve_counter;
   reward_t m_reward_p1;
   reward_t m_reward_p2;
   int m_prev_delta_points;

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -96,7 +96,8 @@ class TennisSettings : public RomSettings2P {
   int max_turn_time;
   int turn_counter;
   int no_serve_counter;
-  reward_t m_reward;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   int m_prev_delta_points;
   int m_prev_delta_score;
 };

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -96,8 +96,7 @@ class TennisSettings : public RomSettings2P {
   int stall_time;
   int turn_counter;
   int no_serve_counter;
-  reward_t m_reward_p1;
-  reward_t m_reward_p2;
+  reward_t m_reward;
   int m_prev_delta_points;
   int m_prev_delta_score;
 };

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -93,7 +93,7 @@ class TennisSettings : public RomSettings2P {
  private:
   bool m_terminal;
   bool two_player_mode;
-  int stall_time;
+  int max_turn_time;
   int turn_counter;
   int no_serve_counter;
   reward_t m_reward;

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -54,6 +54,8 @@ class TennisSettings : public RomSettings2P {
   // The md5 checksum of the ROM that this game supports
   const char* md5() const override { return "42cdd6a9e42a3639e190722b8ea3fc51"; }
 
+  virtual void modifyEnvironmentSettings(Settings& settings);
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 
@@ -91,6 +93,7 @@ class TennisSettings : public RomSettings2P {
  private:
   bool m_terminal;
   bool two_player_mode;
+  int stall_penalty_limit;
   int turn_counter;
   reward_t m_reward_p1;
   reward_t m_reward_p2;

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -90,7 +90,10 @@ class TennisSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward;
+  bool two_player_mode;
+  int turn_counter;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   int m_prev_delta_points;
   int m_prev_delta_score;
 };

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -74,34 +74,35 @@ void VideoCheckersSettings::step(const System& system) {
   }
   turn_same_count += 1;
   m_is_white_turn = is_white_turn;
-
-  m_reward = 0;
-
   // 10 seconds to make a move
   if(max_turn_time > 0 && turn_same_count > max_turn_time){
     //remember white is p2
     if (is_white_turn){
-      m_reward = 1;
+      m_reward_p1 = 0;
+      m_reward_p2 = -1;
     }
     else{
-      m_reward = -1;
+      m_reward_p1 = -1;
+      m_reward_p2 = 0;
     }
     turn_same_count = 0;
   }
 
   if (num_black_pieces == 0) {
-    m_reward = m_reverse_checkers ? +1 : -1;
+    m_reward_p1 = m_reverse_checkers ? +1 : -1;
+    m_reward_p2 = -m_reward_p1;
     m_terminal = true;
   } else if (num_white_pieces == 0) {
-    m_reward = m_reverse_checkers ? -1 : +1;
+    m_reward_p1 = m_reverse_checkers ? -1 : +1;
+    m_reward_p2 = -m_reward_p1;
     m_terminal = true;
   }
 }
 
 bool VideoCheckersSettings::isTerminal() const { return m_terminal; }
 
-reward_t VideoCheckersSettings::getReward() const { return m_reward; }
-reward_t VideoCheckersSettings::getRewardP2() const { return -m_reward; }
+reward_t VideoCheckersSettings::getReward() const { return m_reward_p1; }
+reward_t VideoCheckersSettings::getRewardP2() const { return m_reward_p2; }
 
 void VideoCheckersSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
@@ -127,14 +128,16 @@ bool VideoCheckersSettings::isMinimal(const Action& a) const {
 }
 
 void VideoCheckersSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
   turn_same_count = 0;
   m_is_white_turn = false;
   m_terminal = false;
 }
 
 void VideoCheckersSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
   ser.putInt(turn_same_count);
   ser.putBool(m_is_white_turn);
   ser.putBool(two_player_mode);
@@ -143,7 +146,8 @@ void VideoCheckersSettings::saveState(Serializer& ser) {
 }
 
 void VideoCheckersSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
   turn_same_count = ser.getInt();
   m_is_white_turn = ser.getBool();
   two_player_mode = ser.getBool();

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -84,7 +84,6 @@ void VideoCheckersSettings::step(const System& system) {
       m_reward_p1 = -1;
       m_reward_p2 = 0;
     }
-    m_terminal = true;
   }
 
   if (num_black_pieces == 0) {

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -75,8 +75,7 @@ void VideoCheckersSettings::step(const System& system) {
   turn_same_count += 1;
   m_is_white_turn = is_white_turn;
   // 10 seconds to make a move
-  const int lose_reset_count = 60*10;
-  if(turn_same_count > lose_reset_count){
+  if(stall_penalty_limit > 0 && turn_same_count > stall_penalty_limit){
     if (m_is_white_turn){
       m_reward_p1 = 0;
       m_reward_p2 = -1;
@@ -103,6 +102,15 @@ bool VideoCheckersSettings::isTerminal() const { return m_terminal; }
 
 reward_t VideoCheckersSettings::getReward() const { return m_reward_p1; }
 reward_t VideoCheckersSettings::getRewardP2() const { return m_reward_p2; }
+
+void VideoCheckersSettings::modifyEnvironmentSettings(Settings& settings) {
+  int default_setting = -1;
+  stall_penalty_limit = settings.getInt("stall_penalty_limit");
+  if(stall_penalty_limit == default_setting){
+    const int DEFAULT_STALL_LIMIT = 60*10;
+    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+  }
+}
 
 bool VideoCheckersSettings::isMinimal(const Action& a) const {
   switch (a) {

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -75,7 +75,7 @@ void VideoCheckersSettings::step(const System& system) {
   turn_same_count += 1;
   m_is_white_turn = is_white_turn;
   // 10 seconds to make a move
-  if(stall_penalty_limit > 0 && turn_same_count > stall_penalty_limit){
+  if(stall_time > 0 && turn_same_count > stall_time){
     if (m_is_white_turn){
       m_reward_p1 = 0;
       m_reward_p2 = -1;
@@ -105,10 +105,10 @@ reward_t VideoCheckersSettings::getRewardP2() const { return m_reward_p2; }
 
 void VideoCheckersSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_penalty_limit = settings.getInt("stall_penalty_limit");
-  if(stall_penalty_limit == default_setting){
+  stall_time = settings.getInt("stall_time");
+  if(stall_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*10;
-    stall_penalty_limit = DEFAULT_STALL_LIMIT;
+    stall_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -78,7 +78,7 @@ void VideoCheckersSettings::step(const System& system) {
   m_reward = 0;
 
   // 10 seconds to make a move
-  if(stall_time > 0 && turn_same_count > stall_time){
+  if(max_turn_time > 0 && turn_same_count > max_turn_time){
     //remember white is p2
     if (is_white_turn){
       m_reward = 1;
@@ -105,10 +105,10 @@ reward_t VideoCheckersSettings::getRewardP2() const { return -m_reward; }
 
 void VideoCheckersSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
-  stall_time = settings.getInt("stall_time");
-  if(stall_time == default_setting){
+  max_turn_time = settings.getInt("max_turn_time");
+  if(max_turn_time == default_setting){
     const int DEFAULT_STALL_LIMIT = 60*10;
-    stall_time = DEFAULT_STALL_LIMIT;
+    max_turn_time = DEFAULT_STALL_LIMIT;
   }
 }
 

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -68,20 +68,41 @@ void VideoCheckersSettings::step(const System& system) {
     unsigned char state = readRam(&system, address);
     process_board_state(state, num_black_pieces, num_white_pieces);
   }
+  bool is_white_turn = (readRam(&system, 0xc0) >> 4);
+  if(is_white_turn != m_is_white_turn){
+    turn_same_count = 0;
+  }
+  turn_same_count += 1;
+  m_is_white_turn = is_white_turn;
+  // 10 seconds to make a move
+  const int lose_reset_count = 60*10;
+  if(turn_same_count > lose_reset_count){
+    if (m_is_white_turn){
+      m_reward_p1 = 0;
+      m_reward_p2 = -1;
+    }
+    else{
+      m_reward_p1 = -1;
+      m_reward_p2 = 0;
+    }
+    m_terminal = true;
+  }
 
   if (num_black_pieces == 0) {
-    m_reward = m_reverse_checkers ? +1 : -1;
+    m_reward_p1 = m_reverse_checkers ? +1 : -1;
+    m_reward_p2 = -m_reward_p1;
     m_terminal = true;
   } else if (num_white_pieces == 0) {
-    m_reward = m_reverse_checkers ? -1 : +1;
+    m_reward_p1 = m_reverse_checkers ? -1 : +1;
+    m_reward_p2 = -m_reward_p1;
     m_terminal = true;
   }
 }
 
 bool VideoCheckersSettings::isTerminal() const { return m_terminal; }
 
-reward_t VideoCheckersSettings::getReward() const { return m_reward; }
-reward_t VideoCheckersSettings::getRewardP2() const { return -m_reward; }
+reward_t VideoCheckersSettings::getReward() const { return m_reward_p1; }
+reward_t VideoCheckersSettings::getRewardP2() const { return m_reward_p2; }
 
 bool VideoCheckersSettings::isMinimal(const Action& a) const {
   switch (a) {
@@ -98,18 +119,29 @@ bool VideoCheckersSettings::isMinimal(const Action& a) const {
 }
 
 void VideoCheckersSettings::reset() {
-  m_reward = 0;
+  m_reward_p1 = 0;
+  m_reward_p2 = 0;
+  turn_same_count = 0;
+  m_is_white_turn = false;
   m_terminal = false;
 }
 
 void VideoCheckersSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward);
+  ser.putInt(m_reward_p1);
+  ser.putInt(m_reward_p2);
+  ser.putInt(turn_same_count);
+  ser.putBool(m_is_white_turn);
+  ser.putBool(two_player_mode);
   ser.putBool(m_terminal);
   ser.putBool(m_reverse_checkers);
 }
 
 void VideoCheckersSettings::loadState(Deserializer& ser) {
-  m_reward = ser.getInt();
+  m_reward_p1 = ser.getInt();
+  m_reward_p2 = ser.getInt();
+  turn_same_count = ser.getInt();
+  m_is_white_turn = ser.getBool();
+  two_player_mode = ser.getBool();
   m_terminal = ser.getBool();
   m_reverse_checkers = ser.getBool();
 }
@@ -132,6 +164,7 @@ void VideoCheckersSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
   m_reverse_checkers = m >= 11;
+  two_player_mode = m == 10;
 
   while (getDecimalScore(0xF6, &system) != m) { environment->pressSelect(1); }
 

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -74,34 +74,34 @@ void VideoCheckersSettings::step(const System& system) {
   }
   turn_same_count += 1;
   m_is_white_turn = is_white_turn;
+
+  m_reward = 0;
+
   // 10 seconds to make a move
   if(stall_time > 0 && turn_same_count > stall_time){
-    if (m_is_white_turn){
-      m_reward_p1 = 0;
-      m_reward_p2 = -1;
+    //remember white is p2
+    if (is_white_turn){
+      m_reward = 1;
     }
     else{
-      m_reward_p1 = -1;
-      m_reward_p2 = 0;
+      m_reward = -1;
     }
     turn_same_count = 0;
   }
 
   if (num_black_pieces == 0) {
-    m_reward_p1 = m_reverse_checkers ? +1 : -1;
-    m_reward_p2 = -m_reward_p1;
+    m_reward = m_reverse_checkers ? +1 : -1;
     m_terminal = true;
   } else if (num_white_pieces == 0) {
-    m_reward_p1 = m_reverse_checkers ? -1 : +1;
-    m_reward_p2 = -m_reward_p1;
+    m_reward = m_reverse_checkers ? -1 : +1;
     m_terminal = true;
   }
 }
 
 bool VideoCheckersSettings::isTerminal() const { return m_terminal; }
 
-reward_t VideoCheckersSettings::getReward() const { return m_reward_p1; }
-reward_t VideoCheckersSettings::getRewardP2() const { return m_reward_p2; }
+reward_t VideoCheckersSettings::getReward() const { return m_reward; }
+reward_t VideoCheckersSettings::getRewardP2() const { return -m_reward; }
 
 void VideoCheckersSettings::modifyEnvironmentSettings(Settings& settings) {
   int default_setting = -1;
@@ -127,16 +127,14 @@ bool VideoCheckersSettings::isMinimal(const Action& a) const {
 }
 
 void VideoCheckersSettings::reset() {
-  m_reward_p1 = 0;
-  m_reward_p2 = 0;
+  m_reward = 0;
   turn_same_count = 0;
   m_is_white_turn = false;
   m_terminal = false;
 }
 
 void VideoCheckersSettings::saveState(Serializer& ser) {
-  ser.putInt(m_reward_p1);
-  ser.putInt(m_reward_p2);
+  ser.putInt(m_reward);
   ser.putInt(turn_same_count);
   ser.putBool(m_is_white_turn);
   ser.putBool(two_player_mode);
@@ -145,8 +143,7 @@ void VideoCheckersSettings::saveState(Serializer& ser) {
 }
 
 void VideoCheckersSettings::loadState(Deserializer& ser) {
-  m_reward_p1 = ser.getInt();
-  m_reward_p2 = ser.getInt();
+  m_reward = ser.getInt();
   turn_same_count = ser.getInt();
   m_is_white_turn = ser.getBool();
   two_player_mode = ser.getBool();

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -84,6 +84,7 @@ void VideoCheckersSettings::step(const System& system) {
       m_reward_p1 = -1;
       m_reward_p2 = 0;
     }
+    turn_same_count = 0;
   }
 
   if (num_black_pieces == 0) {

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -53,6 +53,8 @@ class VideoCheckersSettings : public RomSettings2P {
 
   bool isMinimal(const Action& a) const override;
 
+  virtual void modifyEnvironmentSettings(Settings& settings);
+
   void step(const System& system) override;
 
   void saveState(Serializer& ser) override;
@@ -69,6 +71,7 @@ class VideoCheckersSettings : public RomSettings2P {
   bool m_terminal;
   bool m_is_white_turn;
   int turn_same_count;
+  int stall_penalty_limit;
   bool two_player_mode;
   reward_t m_reward_p1;
   reward_t m_reward_p2;

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -67,7 +67,11 @@ class VideoCheckersSettings : public RomSettings2P {
 
  private:
   bool m_terminal;
-  reward_t m_reward;
+  bool m_is_white_turn;
+  int turn_same_count;
+  bool two_player_mode;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   bool m_reverse_checkers;
 };
 

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -71,7 +71,7 @@ class VideoCheckersSettings : public RomSettings2P {
   bool m_terminal;
   bool m_is_white_turn;
   int turn_same_count;
-  int stall_penalty_limit;
+  int stall_time;
   bool two_player_mode;
   reward_t m_reward_p1;
   reward_t m_reward_p2;

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -73,8 +73,7 @@ class VideoCheckersSettings : public RomSettings2P {
   int turn_same_count;
   int stall_time;
   bool two_player_mode;
-  reward_t m_reward_p1;
-  reward_t m_reward_p2;
+  reward_t m_reward;
   bool m_reverse_checkers;
 };
 

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -73,7 +73,8 @@ class VideoCheckersSettings : public RomSettings2P {
   int turn_same_count;
   int max_turn_time;
   bool two_player_mode;
-  reward_t m_reward;
+  reward_t m_reward_p1;
+  reward_t m_reward_p2;
   bool m_reverse_checkers;
 };
 

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -71,7 +71,7 @@ class VideoCheckersSettings : public RomSettings2P {
   bool m_terminal;
   bool m_is_white_turn;
   int turn_same_count;
-  int stall_time;
+  int max_turn_time;
   bool two_player_mode;
   reward_t m_reward;
   bool m_reverse_checkers;

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 void save_frame(std::vector<unsigned char> & Buff);
 
-constexpr int steps_to_test = 2000;
+constexpr int steps_to_test = 20000;
 
 std::vector<std::string> two_player_games;
 void init_two_player_fnames(){

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -12,7 +12,7 @@ constexpr int steps_to_test = 2000;
 std::vector<std::string> two_player_games;
 void init_two_player_fnames(){
   std::vector<std::string> two_player_fnames = {
-    "backgammon",
+    "video_checkers", // this actually passes the tests, the test just doesn't play p1 well by default
     "boxing",
     "combat",
     "double_dunk",
@@ -28,9 +28,8 @@ void init_two_player_fnames(){
     "space_invaders",
     "space_war",
     "surround",
-    "tennis",
-    "video_checkers", // this actually passes the tests, the test just doesn't play p1 well by default
     "wizard_of_wor",
+    "tennis",
     "warlords",
   };
   std::string main_path = "roms/";//"/home/benblack/anaconda3/lib/python3.7/site-packages/ale_py/ROM/";
@@ -103,7 +102,7 @@ size_t play_sequence(ALEInterface & interface,int sequence_num){
 size_t play_sequence_p2(ALEInterface & interface,int sequence_num){
   size_t hashCode = 0;
   std::vector<unsigned char> output_rgb_buffer(192*160*3);
-  save_frame(output_rgb_buffer);
+  //save_frame(output_rgb_buffer);
   ActionVect min_actionsp1 = interface.getMinimalActionSet();
   int action_p2 = 0;
   int action_p1 = 0;
@@ -124,7 +123,7 @@ size_t play_sequence_p2(ALEInterface & interface,int sequence_num){
       break;
     }
     if(j % 14 == 0){
-      save_frame(output_rgb_buffer);
+    //  save_frame(output_rgb_buffer);
     }
   }
   return hashCode;

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 void save_frame(std::vector<unsigned char> & Buff);
 
-constexpr int steps_to_test = 20000;
+constexpr int steps_to_test = 2000;
 
 std::vector<std::string> two_player_games;
 void init_two_player_fnames(){

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -13,9 +13,11 @@ std::vector<std::string> two_player_games;
 void init_two_player_fnames(){
   std::vector<std::string> two_player_fnames = {
     "video_checkers", // this actually passes the tests, the test just doesn't play p1 well by default
+    "tennis",
+    "othello", //othello seems to be working, just isn't passing the test
+    "double_dunk",
     "boxing",
     "combat",
-    "double_dunk",
     "entombed",
     "fishing_derby",
     "flag_capture",
@@ -23,13 +25,11 @@ void init_two_player_fnames(){
     "joust",
     "mario_bros",
     "maze_craze",
-    "othello", //othello seems to be working, just isn't passing the test
     "pong",
     "space_invaders",
     "space_war",
     "surround",
     "wizard_of_wor",
-    "tennis",
     "warlords",
   };
   std::string main_path = "roms/";//"/home/benblack/anaconda3/lib/python3.7/site-packages/ale_py/ROM/";


### PR DESCRIPTION
* Affects multi-player games where one player can unilaterally halt play by not taking their turn. 
* Specifically: video checkers, othello, double dunk, tennis.
* Only affects multi-player versions of the games.
* Gives negative rewards for player not moving gameplay forward

game | reward |  default time
--- | --- | ---
video checkers | -1 |  10s
double dunk | -1 | 2s
othello | -1 (is this too small?) | 10s
 tennis | -1 | 3s

Also allows the time to be set by a new int setting:

```
# sets the stall timer to 10s, or 600 frames. 
ale.setInt("max_turn_time", 60*10);
```