### PR TITLE
fixed entombed cooperative rewards

### DIFF
--- a/src/games/supported/Entombed.cpp
+++ b/src/games/supported/Entombed.cpp
@@ -49,7 +49,7 @@ void EntombedSettings::step(const System& system) {
 
   if(is_two_player){
     if(is_cooperative){
-      if(cur_substage == cur_depth+1){
+      if(cur_substage >= cur_depth){
         //rewards every 5 seconds after the first 10 seconds after starting a stage
         m_reward = 1;
       }

--- a/src/games/supported/Entombed.cpp
+++ b/src/games/supported/Entombed.cpp
@@ -49,7 +49,7 @@ void EntombedSettings::step(const System& system) {
 
   if(is_two_player){
     if(is_cooperative){
-      if(cur_substage >= cur_depth){
+      if(cur_substage > cur_depth){
         //rewards every 5 seconds after the first 10 seconds after starting a stage
         m_reward = 1;
       }

--- a/src/games/supported/Entombed.hpp
+++ b/src/games/supported/Entombed.hpp
@@ -72,7 +72,7 @@ class EntombedSettings : public RomSettings2P {
 
 
  private:
-  int depth_counter;
+  int cur_depth;
   bool m_terminal;
   reward_t m_reward;
   int m_score;


### PR DESCRIPTION
Entombed is separated into a number of stages, each stage having 5 invisible parts. 

Each stage is faster than the one previous, when you die, you go back to the beginning of the stage.

In this PR, you are rewarded for progressing onto the next part of a current stage, or for starting a new stage. This means you get a maximum of 5 reward per stage (unless you die, then you get to repeat a stage). It also means that when you lose 1 life, you always get a reward immediately afterwards. This is not a bug, this is reflective of the actual functionality in the single player game. 

The way to maximize discounted reward in this game is to advance to the latest stage you can reliably complete, then make sure to die right before finishing it, so you can do it over and over again.