### PR TITLE
Add ability to set RAM

### DIFF
--- a/multi_agent_ale_py/ale_c_wrapper.h
+++ b/multi_agent_ale_py/ale_c_wrapper.h
@@ -82,6 +82,9 @@ extern "C" {
     int size = ale->getRAM().size();
     std::memcpy(ram,ale_ram,size*sizeof(unsigned char));
   }
+  void setRAM(ale::ALEInterface *ale, size_t memory_index, ale::byte_t value) {
+    return ale->setRAM(memory_index, value);
+  }
   int getRAMSize(ale::ALEInterface *ale){return ale->getRAM().size();}
   int getScreenWidth(ale::ALEInterface *ale){return ale->getScreen().width();}
   int getScreenHeight(ale::ALEInterface *ale){return ale->getScreen().height();}

--- a/multi_agent_ale_py/ale_python_interface.py
+++ b/multi_agent_ale_py/ale_python_interface.py
@@ -340,7 +340,13 @@ class ALEInterface(object):
         return ram
 
     def setRAM(self, memory_index, value):
-        return ale_lib.setRAM(self.obj, as_ctypes(memory_index), as_ctypes(value))
+        """Set ram at memory_index to value"""
+        if not 0 <= memory_index <= 127:
+            raise RuntimeError("Index out of bounds.")
+        if not 0 <= value <= 255:
+            raise RuntimeError("Invalid ram value.")
+        return ale_lib.setRAM(self.obj, memory_index, value)
+
     def saveScreenPNG(self, filename):
         """Save the current screen as a png file"""
         return ale_lib.saveScreenPNG(self.obj, _str_as_bytes(filename))

--- a/multi_agent_ale_py/ale_python_interface.py
+++ b/multi_agent_ale_py/ale_python_interface.py
@@ -108,6 +108,8 @@ ale_lib.getRAM.argtypes = [c_void_p, c_void_p]
 ale_lib.getRAM.restype = None
 ale_lib.getRAMSize.argtypes = [c_void_p]
 ale_lib.getRAMSize.restype = c_int
+ale_lib.setRAM.argtypes = [c_size_t, c_ubyte]
+ale_lib.setRAM.restype = None
 ale_lib.getScreenWidth.argtypes = [c_void_p]
 ale_lib.getScreenWidth.restype = c_int
 ale_lib.getScreenHeight.argtypes = [c_void_p]
@@ -337,6 +339,8 @@ class ALEInterface(object):
         ale_lib.getRAM(self.obj, as_ctypes(ram))
         return ram
 
+    def setRAM(self, memory_index, value):
+        return ale_lib.setRAM(self.obj, as_ctypes(memory_index), as_ctypes(value))
     def saveScreenPNG(self, filename):
         """Save the current screen as a png file"""
         return ale_lib.saveScreenPNG(self.obj, _str_as_bytes(filename))

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -506,6 +506,10 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) {
 // Returns the current RAM content
 const ALERAM& ALEInterface::getRAM() { return environment->getRAM(); }
 
+void ALEInterface::setRAM(size_t memory_index, byte_t value) {
+  return environment->setRAM(memory_index, value);
+}
+
 // Saves the state of the system
 void ALEInterface::saveState() { environment->save(); }
 

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -168,6 +168,8 @@ class ALEInterface {
   // Returns the current RAM content
   const ALERAM& getRAM();
 
+  void setRAM(size_t memory_index, byte_t value);
+
   // Saves the state of the system
   void saveState();
 

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -322,4 +322,9 @@ void StellaEnvironment::processRAM() {
     *m_ram.byte(i) = m_osystem->console().system().peek(i + 0x80);
 }
 
+void StellaEnvironment::setRAM(size_t memory_index, byte_t value) {
+  m_osystem->console().system().poke(memory_index + 0x80, value);
+  *m_ram.byte(memory_index) = value;
+}
+
 }  // namespace ale

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -113,6 +113,8 @@ class StellaEnvironment {
   /** Returns a wrapper providing #include-free access to our methods. */
   std::unique_ptr<StellaEnvironmentWrapper> getWrapper();
 
+  void setRAM(size_t memory_index, byte_t value);
+
  private:
   /** This applies an action exactly one time step. Helper function to act(). */
   void oneStepAct(std::vector<Action> actions,std::vector<reward_t> & rewards);


### PR DESCRIPTION
`setRAM` allows changing the Atari RAM values by their index.

```
ale = multi_agent_ale_py.ALEInterface()
ram = ale.getRAM()  # getRAM returns a numpy uint8 array with current RAM values
ale.setRAM(np.array(0x18, dtype='uint8'), np.array(0, dtype='uint8'))  # sets RAM value at index 24 to 0 
ram = ale.getRAM()  # RAM is updated
```

This is useful for implementing overrides of game state, e.g. introducing randomness or external rules for the game.

Related stale PRs: https://github.com/mgbellemare/Arcade-Learning-Environment/pull/247, https://github.com/mgbellemare/Arcade-Learning-Environment/pull/232. We would like to contribute our changes upstream. It seems the best option is to include the changes in this repo as it is used in our project.
