### PR TITLE
Fix build error

### DIFF
--- a/src/games/supported/Backgammon.cpp
+++ b/src/games/supported/Backgammon.cpp
@@ -25,6 +25,8 @@
  * *****************************************************************************
  */
 
+#include <cstdint>
+
 #include "Backgammon.hpp"
 
 #include "../RomUtils.hpp"

--- a/src/games/supported/VideoCube.cpp
+++ b/src/games/supported/VideoCube.cpp
@@ -26,6 +26,7 @@
 #include "VideoCube.hpp"
 
 #include <cmath>
+#include <cstdint>
 #include <stdexcept>
 
 #include "../RomUtils.hpp"


### PR DESCRIPTION
Fix Build Error

In `src/games/supported/Backgammon.cpp`:

```text
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:34:6: error: ‘int8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   34 | std::int8_t readPieces(const System* system, int offset) {
      |      ^~~~~~
      |      wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp: In member function ‘virtual void ale::BackgammonSettings::step(const System&)’:
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:79:8: error: ‘int8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   79 |   std::int8_t num_player_pieces_out = -readPieces(&system, 0x80);
      |        ^~~~~~
      |        wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:80:8: error: ‘int8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   80 |   std::int8_t num_computer_pieces_out = readPieces(&system, 0x8E);
      |        ^~~~~~
      |        wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:82:8: error: ‘int8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   82 |   std::int8_t num_player_pieces_in = 0;
      |        ^~~~~~
      |        wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:83:8: error: ‘int8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   83 |   std::int8_t num_computer_pieces_in = 0;
      |        ^~~~~~
      |        wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/Backgammon.cpp:88:10: error: ‘int8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   88 |     std::int8_t pieces = readPieces(&system, address);
      |          ^~~~~~
      |          wint_t
```

In `src/games/supported/VideoCube.cpp`:

```text
/home/rocco/code/Multi-Agent-ALE/src/games/supported/VideoCube.cpp:75:12: error: ‘uint8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   75 | const std::uint8_t kFaceStartAddress = 0xa0;
      |            ^~~~~~~
      |            wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/VideoCube.cpp: In member function ‘virtual void ale::VideoCubeSettings::step(const System&)’:
/home/rocco/code/Multi-Agent-ALE/src/games/supported/VideoCube.cpp:94:8: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   94 |   std::uint8_t blockAddress = kFaceStartAddress;
      |        ^~~~~~~
      |        wint_t
/home/rocco/code/Multi-Agent-ALE/src/games/supported/VideoCube.cpp:97:10: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   97 |     std::uint8_t firstColourBlock = readRam(&system, blockAddress);
      |          ^~~~~~~
      |          wint_t
```